### PR TITLE
Split source material

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -27,19 +27,20 @@
      "output_type": "stream",
      "text": [
       "<class 'str'>\n",
-      "119846\n",
-      "﻿***The Project Gutenberg's Etext of Shakespeare's First Folio***\r\n",
+      "120253\n",
+      "﻿\r\n",
+      "\r\n",
+      "***The Project Gutenberg's Etext of Shakespeare's First Folio***\r\n",
       "********************The Tragedie of Macbeth*********************\r\n",
       "\r\n",
-      "This is our 3rd edition of most of these plays.  See the index.\r\n",
       "\r\n",
       "\r\n",
-      "Copyright laws are changing all over the world, be sure to check\r\n",
-      "the copyright laws for your country before posting these files!!\r\n",
-      "\r\n",
-      "Please take a look at the important information in this header.\r\n",
-      "We encourage you to keep this file on your own disk, keeping an\r\n",
-      "electronic path open for the nex\n"
+      "*******************************************************************\r\n",
+      "THIS EBOOK WAS ONE OF PROJECT GUTENBERG'S EARLY FILES PRODUCED AT A\r\n",
+      "TIME WHEN PROOFING METHODS AND TOOLS WERE NOT WELL DEVELOPED. THERE\r\n",
+      "IS AN IMPROVED EDITION OF THIS TITLE WHICH MAY BE VIEWED AS EBOOK\r\n",
+      "(#1533) at https://www.gutenberg.org/ebooks/1533\r\n",
+      "*********************************\n"
      ]
     }
    ],
@@ -49,7 +50,12 @@
     "\n",
     "print(type(macbeth))\n",
     "print(len(macbeth))\n",
-    "print(macbeth[:500])"
+    "print(macbeth[:500])\n",
+    "\n",
+    "minus_Gutenberg = macbeth[16645:20000]\n",
+    "#intro = 'The Tragedie of Macbeth'\n",
+    "#intro.index(macbeth)\n",
+    "#print()"
    ]
   },
   {
@@ -66,13 +72,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['The', 'Tragedie', 'of', 'Macbeth', 'Actus', 'Primus', 'Scoena', 'Prima', 'Thunder', 'and', 'Lightning', 'Enter', 'three', 'Witches', '1', 'When', 'shall', 'we', 'three', 'meet', 'againe', 'In', 'Thunder', 'Lightning', 'or', 'in', 'Raine', '2', 'When', 'the', \"Hurley-burley's\", 'done', 'When', 'the', \"Battaile's\", 'lost', 'and', 'wonne', '3', 'That', 'will', 'be', 'ere', 'the', 'set', 'of', 'Sunne', '1', 'Where', 'the', 'place', '2', 'Vpon', 'the', 'Heath', '3', 'There', 'to', 'meet', 'with', 'Macbeth', '1', 'I', 'come', 'Gray-Malkin', 'All', 'Padock', 'calls', 'anon', 'faire', 'is', 'foule', 'and', 'foule', 'is', 'faire', 'Houer', 'through', 'the', 'fogge', 'and', 'filthie', 'ayre', 'Exeunt', 'Scena', 'Secunda', 'Alarum', 'within', 'Enter', 'King', 'Malcome', 'Donalbaine', 'Lenox', 'with', 'attendants', 'meeting', 'a', 'bleeding', 'Captaine', 'King', 'What', 'bloody', 'man', 'is', 'that', 'he', 'can', 'report', 'As', 'seemeth', 'by', 'his', 'plight', 'of', 'the', 'Reuolt', 'The', 'newest', 'state', 'Mal', 'This', 'is', 'the', 'Serieant', 'Who', 'like', 'a', 'good', 'and', 'hardie', 'Souldier', 'fought', \"'Gainst\", 'my', 'Captiuitie', 'Haile', 'braue', 'friend', 'Say', 'to', 'the', 'King', 'the', 'knowledge', 'of', 'the', 'Broyle', 'As', 'thou', 'didst', 'leaue', 'it', 'Cap', 'Doubtfull', 'it', 'stood', 'As', 'two', 'spent', 'Swimmers', 'that', 'doe', 'cling', 'together', 'And', 'choake', 'their', 'Art', 'The', 'mercilesse', 'Macdonwald', '(Worthie', 'to', 'be', 'a', 'Rebell', 'for', 'to', 'that', 'The', 'multiplying', 'Villanies', 'of', 'Nature', 'Doe', 'swarme', 'vpon', 'him)', 'from', 'the', 'Westerne', 'Isles', 'Of', 'Kernes', 'and', 'Gallowgrosses', 'is', \"supply'd\", 'And', 'Fortune', 'on', 'his', 'damned', 'Quarry', 'smiling', \"Shew'd\", 'like', 'a', 'Rebells', 'Whore', 'but', \"all's\", 'too', 'weake', 'For', 'braue', 'Macbeth', '(well', 'hee', 'deserues', 'that', 'Name)', 'Disdayning', 'Fortune', 'with', 'his', 'brandisht', 'Steele', 'Which', \"smoak'd\", 'with', 'bloody', 'execution', '(Like', 'Valours', 'Minion)', \"caru'd\", 'out', 'his', 'passage', 'Till', 'hee', \"fac'd\", 'the', 'Slaue', 'Which', \"neu'r\", 'shooke', 'hands', 'nor', 'bad', 'farwell', 'to', 'him', 'Till', 'he', \"vnseam'd\", 'him', 'from', 'the', 'Naue', \"toth'\", 'Chops', 'And', \"fix'd\", 'his', 'Head', 'vpon', 'our', 'Battlements', 'King', 'O', 'valiant', 'Cousin', 'worthy', 'Gentleman', 'Cap', 'As', 'whence', 'the', 'Sunne', \"'gins\", 'his', 'reflection', 'Shipwracking', 'Stormes', 'and', 'direfull', 'Thunders', 'So', 'from', 'that', 'Spring', 'whence', 'comfort', \"seem'd\", 'to', 'come', 'Discomfort', 'swells', 'Marke', 'King', 'of', 'Scotland', 'marke', 'No', 'sooner', 'Iustice', 'had', 'with', 'Valour', \"arm'd\", \"Compell'd\", 'these', 'skipping', 'Kernes', 'to', 'trust', 'their', 'heeles', 'But', 'the', 'Norweyan', 'Lord', 'surueying', 'vantage', 'With', 'furbusht', 'Armes', 'and', 'new', 'supplyes', 'of', 'men', 'Began', 'a', 'fresh', 'assault', 'King', \"Dismay'd\", 'not', 'this', 'our', 'Captaines', 'Macbeth', 'and', 'Banquoh', 'Cap', 'Yes', 'as', 'Sparrowes', 'Eagles', 'Or', 'the', 'Hare', 'the', 'Lyon', 'If', 'I', 'say', 'sooth', 'I', 'must', 'report', 'they', 'were', 'As', 'Cannons', \"ouer-charg'd\", 'with', 'double', 'Cracks', 'So', 'they', 'doubly', 'redoubled', 'stroakes', 'vpon', 'the', 'Foe', 'Except', 'they', 'meant', 'to', 'bathe', 'in', 'reeking', 'Wounds', 'Or', 'memorize', 'another', 'Golgotha', 'I', 'cannot', 'tell', 'but', 'I', 'am', 'faint', 'My', 'Gashes', 'cry', 'for', 'helpe', 'King', 'So', 'well', 'thy', 'words', 'become', 'thee', 'as', 'thy', 'wounds', 'They', 'smack', 'of', 'Honor', 'both', 'Goe', 'get', 'him', 'Surgeons', 'Enter', 'Rosse', 'and', 'Angus', 'Who', 'comes', 'here', 'Mal', 'The', 'worthy', 'Thane', 'of', 'Rosse', 'Lenox', 'What', 'a', 'haste', 'lookes', 'through', 'his', 'eyes', 'So', 'should', 'he', 'looke', 'that', 'seemes', 'to', 'speake', 'things', 'strange', 'Rosse', 'God', 'saue', 'the', 'King', 'King', 'Whence', \"cam'st\", 'thou', 'worthy', 'Thane', 'Rosse', 'From', 'Fiffe', 'great', 'King', 'Where', 'the', 'Norweyan', 'Banners', 'flowt', 'the', 'Skie', 'And', 'fanne', 'our', 'people', 'cold', 'Norway', 'himselfe', 'with', 'terrible', 'numbers', 'Assisted', 'by', 'that', 'most', 'disloyall', 'Traytor', 'The', 'Thane', 'of', 'Cawdor', 'began', 'a', 'dismall', 'Conflict', 'Till', 'that', \"Bellona's\", 'Bridegroome', 'lapt', 'in', 'proofe', 'Confronted', 'him', 'with', 'selfe-comparisons', 'Point', 'against', 'Point', 'rebellious', 'Arme', \"'gainst\", 'Arme', 'Curbing', 'his', 'lauish', 'spirit', 'and', 'to', 'conclude', 'The', 'Vict']\n"
+     ]
+    }
+   ],
    "source": [
     "# Your code here\n",
+    "first_repl = minus_Gutenberg.replace('*', ' ')\n",
+    "second_repl = first_repl.replace('.', ' ')\n",
+    "third_repl = second_repl.replace(', ', ' ')\n",
+    "fourth_repl = third_repl.replace('!', ' ')\n",
+    "fifth_repl = fourth_repl.replace(',', ' ')\n",
+    "sixth_repl = fifth_repl.replace(':', ' ')\n",
+    "seventh_repl = sixth_repl.replace(';', ' ')\n",
+    "eigth_repl = seventh_repl.replace('?', ' ')\n",
+    "\n",
+    "first_split = eigth_repl.split()\n",
+    "\n",
+    "print(first_split)\n",
     "\n",
     "# Pseudo-code Outline\n",
     "# Split the transcript into words\n",
@@ -116,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
"""
Take the original Macbeth, remove the Gutenberg intro text, replace all forms of punctuations with spaces, split the long line of text into a list of individual words.
"""